### PR TITLE
scan メソッドで全件取得ができない問題の修正

### DIFF
--- a/DynamoDBWrapper.php
+++ b/DynamoDBWrapper.php
@@ -116,9 +116,14 @@ class DynamoDBWrapper
 
     public function scan($tableName, $filter, $limit = null)
     {
+        if (empty($filter)) {
+            $scanFilter = null;
+        } else {
+            $scanFilter = $this->convertConditions($filter);
+        }
         $items = $this->client->getIterator('Scan', array(
             'TableName' => $tableName,
-            'ScanFilter' => $this->convertConditions($filter),
+            'ScanFilter' => $scanFilter,
         ));
         return $this->convertItems($items);
     }


### PR DESCRIPTION
$filterに null, array() が指定された場合に全件取得できるように修正
